### PR TITLE
qemu: Add run_iozone.py example

### DIFF
--- a/qemu/run_iozone.py
+++ b/qemu/run_iozone.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+
+from avocado.virt import test
+
+
+class run_iozone(test.VirtTest):
+
+    def action(self):
+        self.vm.power_on()
+        self.vm.login_remote()
+        self.whiteboard = self.vm.remote.run('iozone -a').stdout
+
+    def cleanup(self):
+        self.vm.remote.run('shutdown -h now')
+        self.vm.power_off()

--- a/qemu/run_iozone.py.data/run_iozone.yaml
+++ b/qemu/run_iozone.py.data/run_iozone.yaml
@@ -1,0 +1,12 @@
+iozone:
+    avocado.args.run.guest_image_path: /home/user/avocado/data/images/distro-with-iozone.qcow2
+    avocado.args.run.guest_user: john_doe
+    avocado.args.run.guest_password: pass1
+    2472b6c:
+        avocado.args.run.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_2472b6c
+    f383611:
+        avocado.args.run.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_f383611
+    1b53eab:
+        avocado.args.run.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_1b53eab
+    f5bebbb:
+        avocado.args.run.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_f5bebbb


### PR DESCRIPTION
Add an example of test that runs the iozone benchmark on
a qemu vm over a range of qemu commits. Add a multiplex
file that supports the test execution, through the command
line:

avocado run qemu/run_iozone.py --multiplex qemu/run_iozone.py.data/run_iozone.yaml

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
