### PR TITLE
[V2] qemu: Add usb_boot.py test

### DIFF
--- a/qemu/usb_boot.py
+++ b/qemu/usb_boot.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+from avocado.virt import test
+from avocado.core import exceptions
+
+
+class usb_boot(test.VirtTest):
+
+    """
+    1) Add a USB device to a QEMU VM
+    2) Verify that the device shows up on 'info usb' monitor command
+    3) Verify that the device shows up on 'lsusb -v' shell command
+    4) Verify that there are no IO Errors showing on dmesg after
+       2) and 3) are done.
+    """
+
+    def action(self):
+        usb_bus_cmdline = self.params.get('avocado.virt.tests.usb_boot.usb_bus_cmdline',
+                                          '-device piix3-usb-uhci,id=usbtest,bus=pci.0,addr=05')
+        self.vm.devices.add_cmdline(usb_bus_cmdline)
+        usb_device_cmdline = self.params.get('avocado.virt.tests.usb_boot.usb_device_cmdline',
+                                             '-device usb-tablet,id=usb-tablet,bus=usbtest.0,port=1')
+        self.vm.devices.add_cmdline(usb_device_cmdline)
+        self.vm.power_on()
+        self.vm.login_remote()
+
+        check_cmd = self.params.get('avocado.virt.tests.usb_boot.check_cmd', 'lsusb -v')
+        device_name = self.params.get('avocado.virt.tests.usb_boot.device_name', 'QEMU USB Tablet')
+
+        failures = {'monitor': None, 'check_cmd': None, 'dmesg': None}
+
+        # First, we have to clean the guest's dmesg
+        self.vm.remote.run('dmesg -c')
+
+        args = {'command-line': 'info usb'}
+        result_monitor = self.vm.qmp('human-monitor-command', **args)
+        if device_name not in result_monitor['return']:
+            failures['monitor'] = 'Could not find %s in monitor info usb output' % device_name
+
+        result_check = self.vm.remote.run(check_cmd)
+        device_found = False
+        for line in result_check.stdout.splitlines():
+            if device_name in line:
+                device_found = True
+        if not device_found:
+            failures['check_cmd'] = 'Could not find %s in %s output' % (device_name, check_cmd)
+
+        # Now check it again, to see if we don't have IO Errors
+        result_dmesg = self.vm.remote.run('dmesg -c')
+        error_lines = []
+        for line in result_dmesg.stdout.splitlines():
+            if 'error' in line:
+                error_lines.append(line)
+        if error_lines:
+            self.log.error('Errors found on dmesg')
+            for line in error_lines:
+                self.log.error(line)
+            failures['dmesg'] = 'Errors found on guest dmesg'
+
+        e_msg = []
+        for key in failures:
+            if failures[key] is not None:
+                self.log.error(failures[key])
+                e_msg.append(key)
+
+        if e_msg:
+            raise exceptions.TestFail('USB boot test found problems in: %s' % " ".join(e_msg))
+
+    def cleanup(self):
+        self.vm.remote.run('shutdown -h now')
+        self.vm.power_off()

--- a/qemu/usb_boot.py.data/usb_boot.yaml
+++ b/qemu/usb_boot.py.data/usb_boot.yaml
@@ -1,0 +1,15 @@
+usb_boot:
+    avocado.virt.tests.usb_boot.usb_bus_cmdline: '-device piix3-usb-uhci,id=usbtest,bus=pci.0,addr=05'
+    avocado.virt.tests.usb_boot.check_cmd: lsusb -v
+    tablet:
+        avocado.virt.tests.usb_boot.usb_device_cmdline: '-device usb-tablet,id=usb-tablet,bus=usbtest.0,port=1'
+        avocado.virt.tests.usb_boot.device_name: 'QEMU USB Tablet'
+    keyboard:
+        avocado.virt.tests.usb_boot.usb_device_cmdline: '-device usb-kbd,id=usb-kbd,bus=usbtest.0,port=1'
+        avocado.virt.tests.usb_boot.device_name: 'QEMU USB Keyboard'
+    mouse:
+        avocado.virt.tests.usb_boot.usb_device_cmdline: '-device usb-mouse,id=usb-mouse,bus=usbtest.0,port=1'
+        avocado.virt.tests.usb_boot.device_name: 'QEMU USB Mouse'
+    audio:
+        avocado.virt.tests.usb_boot.usb_device_cmdline: '-device usb-audio,id=usb-audio,bus=usbtest.0,port=1'
+        avocado.virt.tests.usb_boot.device_name: 'QEMU USB Audio'


### PR DESCRIPTION
1) Add a USB device to a QEMU VM
2) Verify that the device shows up on 'info usb' monitor command
3) Verify that the device shows up on 'lsusb -v' shell command
4) Verify that there are no IO Errors showing on dmesg after
   2) and 3) are done.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>