### PR TITLE
qemu: Update variable references

### DIFF
--- a/qemu/run_iozone.py.data/run_iozone.yaml
+++ b/qemu/run_iozone.py.data/run_iozone.yaml
@@ -1,12 +1,12 @@
 iozone:
-    avocado.args.run.guest_image_path: /home/user/avocado/data/images/distro-with-iozone.qcow2
-    avocado.args.run.guest_user: john_doe
-    avocado.args.run.guest_password: pass1
+    virt.guest.image_path: /home/user/avocado/data/images/distro-with-iozone.qcow2
+    virt.guest.user: john_doe
+    virt.guest.password: pass1
     2472b6c:
-        avocado.args.run.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_2472b6c
+        virt.qemu.paths.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_2472b6c
     f383611:
-        avocado.args.run.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_f383611
+        virt.qemu.paths.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_f383611
     1b53eab:
-        avocado.args.run.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_1b53eab
+        virt.qemu.paths.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_1b53eab
     f5bebbb:
-        avocado.args.run.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_f5bebbb
+        virt.qemu.paths.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_f5bebbb

--- a/qemu/usb_boot.py
+++ b/qemu/usb_boot.py
@@ -14,8 +14,8 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-from avocado.virt import test
-from avocado.core import exceptions
+from virt import test
+from core import exceptions
 
 
 class usb_boot(test.VirtTest):
@@ -29,17 +29,17 @@ class usb_boot(test.VirtTest):
     """
 
     def action(self):
-        usb_bus_cmdline = self.params.get('avocado.virt.tests.usb_boot.usb_bus_cmdline',
+        usb_bus_cmdline = self.params.get('virt.tests.usb_boot.usb_bus_cmdline',
                                           '-device piix3-usb-uhci,id=usbtest,bus=pci.0,addr=05')
         self.vm.devices.add_cmdline(usb_bus_cmdline)
-        usb_device_cmdline = self.params.get('avocado.virt.tests.usb_boot.usb_device_cmdline',
+        usb_device_cmdline = self.params.get('virt.tests.usb_boot.usb_device_cmdline',
                                              '-device usb-tablet,id=usb-tablet,bus=usbtest.0,port=1')
         self.vm.devices.add_cmdline(usb_device_cmdline)
         self.vm.power_on()
         self.vm.login_remote()
 
-        check_cmd = self.params.get('avocado.virt.tests.usb_boot.check_cmd', 'lsusb -v')
-        device_name = self.params.get('avocado.virt.tests.usb_boot.device_name', 'QEMU USB Tablet')
+        check_cmd = self.params.get('virt.tests.usb_boot.check_cmd', 'lsusb -v')
+        device_name = self.params.get('virt.tests.usb_boot.device_name', 'QEMU USB Tablet')
 
         failures = {'monitor': None, 'check_cmd': None, 'dmesg': None}
 

--- a/qemu/usb_boot.py.data/usb_boot.yaml
+++ b/qemu/usb_boot.py.data/usb_boot.yaml
@@ -1,15 +1,15 @@
 usb_boot:
-    avocado.virt.tests.usb_boot.usb_bus_cmdline: '-device piix3-usb-uhci,id=usbtest,bus=pci.0,addr=05'
-    avocado.virt.tests.usb_boot.check_cmd: lsusb -v
+    virt.tests.usb_boot.usb_bus_cmdline: '-device piix3-usb-uhci,id=usbtest,bus=pci.0,addr=05'
+    virt.tests.usb_boot.check_cmd: lsusb -v
     tablet:
-        avocado.virt.tests.usb_boot.usb_device_cmdline: '-device usb-tablet,id=usb-tablet,bus=usbtest.0,port=1'
-        avocado.virt.tests.usb_boot.device_name: 'QEMU USB Tablet'
+        virt.tests.usb_boot.usb_device_cmdline: '-device usb-tablet,id=usb-tablet,bus=usbtest.0,port=1'
+        virt.tests.usb_boot.device_name: 'QEMU USB Tablet'
     keyboard:
-        avocado.virt.tests.usb_boot.usb_device_cmdline: '-device usb-kbd,id=usb-kbd,bus=usbtest.0,port=1'
-        avocado.virt.tests.usb_boot.device_name: 'QEMU USB Keyboard'
+        virt.tests.usb_boot.usb_device_cmdline: '-device usb-kbd,id=usb-kbd,bus=usbtest.0,port=1'
+        virt.tests.usb_boot.device_name: 'QEMU USB Keyboard'
     mouse:
-        avocado.virt.tests.usb_boot.usb_device_cmdline: '-device usb-mouse,id=usb-mouse,bus=usbtest.0,port=1'
-        avocado.virt.tests.usb_boot.device_name: 'QEMU USB Mouse'
+        virt.tests.usb_boot.usb_device_cmdline: '-device usb-mouse,id=usb-mouse,bus=usbtest.0,port=1'
+        virt.tests.usb_boot.device_name: 'QEMU USB Mouse'
     audio:
-        avocado.virt.tests.usb_boot.usb_device_cmdline: '-device usb-audio,id=usb-audio,bus=usbtest.0,port=1'
-        avocado.virt.tests.usb_boot.device_name: 'QEMU USB Audio'
+        virt.tests.usb_boot.usb_device_cmdline: '-device usb-audio,id=usb-audio,bus=usbtest.0,port=1'
+        virt.tests.usb_boot.device_name: 'QEMU USB Audio'


### PR DESCRIPTION
Use the new, shorter namespace virt.tests, rather than
avocado.virt.tests.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>