### PR TITLE
qemu: Update class names to reflect new avocado test class naming schema

### DIFF
--- a/qemu/boot.py
+++ b/qemu/boot.py
@@ -17,7 +17,7 @@
 from avocado.virt import test
 
 
-class boot(test.VirtTest):
+class BootTest(test.VirtTest):
 
     def action(self):
         self.vm.power_on()

--- a/qemu/migration/migration.py
+++ b/qemu/migration/migration.py
@@ -17,7 +17,7 @@
 from avocado.virt import test
 
 
-class migration(test.VirtTest):
+class MigrationTest(test.VirtTest):
 
     def action(self):
         self.vm.power_on()

--- a/qemu/run_iozone.py
+++ b/qemu/run_iozone.py
@@ -18,7 +18,7 @@
 from avocado.virt import test
 
 
-class run_iozone(test.VirtTest):
+class RunIOZoneTest(test.VirtTest):
 
     def action(self):
         self.vm.power_on()

--- a/qemu/usb_boot.py
+++ b/qemu/usb_boot.py
@@ -18,7 +18,7 @@ from virt import test
 from core import exceptions
 
 
-class usb_boot(test.VirtTest):
+class USBBootTest(test.VirtTest):
 
     """
     1) Add a USB device to a QEMU VM


### PR DESCRIPTION
We are free from the chains of the old autotest-style test
class naming resolution. Let's update our test names to
the new glorious CamelCase convention.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>