### PR TITLE
qemu.usb_boot: Fix incorrect imports

### DIFF
--- a/qemu/usb_boot.py
+++ b/qemu/usb_boot.py
@@ -14,9 +14,9 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-from virt import test
-from core import exceptions
 
+from avocado.virt import test
+from avocado.core import exceptions
 
 class USBBootTest(test.VirtTest):
 


### PR DESCRIPTION
virt/core are not in the default path, we have to use avocado.virt/core
instead.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>