### PR TITLE
qemu: Fix cleanups in case vm or remote was not initialized

### DIFF
--- a/qemu/boot.py
+++ b/qemu/boot.py
@@ -24,5 +24,9 @@ class BootTest(test.VirtTest):
         self.vm.login_remote()
 
     def cleanup(self):
-        self.vm.remote.run('shutdown -h now')
-        self.vm.power_off()
+        if self.vm:
+            if self.vm.remote:
+                self.vm.remote.run('shutdown -h now')
+                # TODO: Wait for machine to go down
+            self.vm.power_off()
+

--- a/qemu/migration/migration.py
+++ b/qemu/migration/migration.py
@@ -27,5 +27,9 @@ class MigrationTest(test.VirtTest):
             self.vm.login_remote()
 
     def cleanup(self):
-        self.vm.remote.run('shutdown -h now')
-        self.vm.power_off()
+        if self.vm:
+            if self.vm.remote:
+                self.vm.remote.run('shutdown -h now')
+                # TODO: Wait for machine to go down
+            self.vm.power_off()
+

--- a/qemu/run_iozone.py
+++ b/qemu/run_iozone.py
@@ -26,5 +26,9 @@ class RunIOZoneTest(test.VirtTest):
         self.whiteboard = self.vm.remote.run('iozone -a').stdout
 
     def cleanup(self):
-        self.vm.remote.run('shutdown -h now')
-        self.vm.power_off()
+        if self.vm:
+            if self.vm.remote:
+                self.vm.remote.run('shutdown -h now')
+                # TODO: Wait for machine to go down
+            self.vm.power_off()
+

--- a/qemu/usb_boot.py
+++ b/qemu/usb_boot.py
@@ -81,5 +81,9 @@ class USBBootTest(test.VirtTest):
             raise exceptions.TestFail('USB boot test found problems in: %s' % " ".join(e_msg))
 
     def cleanup(self):
-        self.vm.remote.run('shutdown -h now')
-        self.vm.power_off()
+        if self.vm:
+            if self.vm.remote:
+                self.vm.remote.run('shutdown -h now')
+                # TODO: Wait for machine to go down
+            self.vm.power_off()
+


### PR DESCRIPTION
Current implementation of cleanup doesn't behave well when VM or remote
are not initialized. Additionally add TODO: message to wait until VM
goes down as currently we just execute shutdown and immediately
destroy it using monitor. That's not really a nice behavior.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>