### PR TITLE
qemu tests: Adapt to recent changes in avocado

### DIFF
--- a/qemu/boot.py
+++ b/qemu/boot.py
@@ -19,13 +19,10 @@ from avocado.virt import test
 
 class BootTest(test.VirtTest):
 
-    def action(self):
+    def test_boot(self):
         self.vm.power_on()
         self.vm.login_remote()
 
-    def cleanup(self):
+    def tearDown(self):
         if self.vm:
-            if self.vm.remote:
-                self.vm.remote.run('shutdown -h now')
-                # TODO: Wait for machine to go down
             self.vm.power_off()

--- a/qemu/migration/migration.py
+++ b/qemu/migration/migration.py
@@ -19,7 +19,7 @@ from avocado.virt import test
 
 class MigrationTest(test.VirtTest):
 
-    def action(self):
+    def test_migrate(self):
         self.vm.power_on()
         migration_mode = self.params.get('migration_mode', 'tcp')
         for _ in xrange(self.params.get('migration_iterations', 4)):
@@ -28,7 +28,4 @@ class MigrationTest(test.VirtTest):
 
     def cleanup(self):
         if self.vm:
-            if self.vm.remote:
-                self.vm.remote.run('shutdown -h now')
-                # TODO: Wait for machine to go down
             self.vm.power_off()

--- a/qemu/run_iozone.py
+++ b/qemu/run_iozone.py
@@ -20,14 +20,11 @@ from avocado.virt import test
 
 class RunIOZoneTest(test.VirtTest):
 
-    def action(self):
+    def test_iozone(self):
         self.vm.power_on()
         self.vm.login_remote()
         self.whiteboard = self.vm.remote.run('iozone -a').stdout
 
-    def cleanup(self):
+    def tearDown(self):
         if self.vm:
-            if self.vm.remote:
-                self.vm.remote.run('shutdown -h now')
-                # TODO: Wait for machine to go down
             self.vm.power_off()

--- a/qemu/usb_boot.py
+++ b/qemu/usb_boot.py
@@ -22,14 +22,16 @@ from avocado.core import exceptions
 class USBBootTest(test.VirtTest):
 
     """
-    1) Add a USB device to a QEMU VM
-    2) Verify that the device shows up on 'info usb' monitor command
-    3) Verify that the device shows up on 'lsusb -v' shell command
-    4) Verify that there are no IO Errors showing on dmesg after
-       2) and 3) are done.
+    Add a USB device to a QEMU vm and perform sanity checks on both QEMU monitor and guest OS.
     """
+    device_name = None
 
-    def action(self):
+    def setUp(self):
+        """
+        Add a USB device to a QEMU VM
+        """
+        super(USBBootTest, self).setUp()
+        self.device_name = self.params.get('virt.tests.usb_boot.device_name', 'QEMU USB Tablet')
         usb_bus_cmdline = self.params.get('virt.tests.usb_boot.usb_bus_cmdline',
                                           '-device piix3-usb-uhci,id=usbtest,bus=pci.0,addr=05')
         self.vm.devices.add_cmdline(usb_bus_cmdline)
@@ -38,30 +40,10 @@ class USBBootTest(test.VirtTest):
         self.vm.devices.add_cmdline(usb_device_cmdline)
         self.vm.power_on()
         self.vm.login_remote()
-
-        check_cmd = self.params.get('virt.tests.usb_boot.check_cmd', 'lsusb -v')
-        device_name = self.params.get('virt.tests.usb_boot.device_name', 'QEMU USB Tablet')
-
-        failures = {'monitor': None, 'check_cmd': None, 'dmesg': None}
-
-        # First, we have to clean the guest's dmesg
         self.vm.remote.run('dmesg -c')
 
-        args = {'command-line': 'info usb'}
-        result_monitor = self.vm.qmp('human-monitor-command', **args)
-        if device_name not in result_monitor['return']:
-            failures['monitor'] = 'Could not find %s in monitor info usb output' % device_name
-
-        result_check = self.vm.remote.run(check_cmd)
-        device_found = False
-        for line in result_check.stdout.splitlines():
-            if device_name in line:
-                device_found = True
-        if not device_found:
-            failures['check_cmd'] = 'Could not find %s in %s output' % (device_name, check_cmd)
-
-        # Now check it again, to see if we don't have IO Errors
-        result_dmesg = self.vm.remote.run('dmesg -c')
+    def check_io_errors(self):
+        result_dmesg = self.vm.remote.run('dmesg')
         error_lines = []
         for line in result_dmesg.stdout.splitlines():
             if 'error' in line:
@@ -70,20 +52,32 @@ class USBBootTest(test.VirtTest):
             self.log.error('Errors found on dmesg')
             for line in error_lines:
                 self.log.error(line)
-            failures['dmesg'] = 'Errors found on guest dmesg'
+            raise exceptions.TestFail('Errors found on guest dmesg')
 
-        e_msg = []
-        for key in failures:
-            if failures[key] is not None:
-                self.log.error(failures[key])
-                e_msg.append(key)
+    def test_shows_monitor(self):
+        """
+        Verify that the device shows up in QEMU monitor 'info usb' command.
+        """
+        args = {'command-line': 'info usb'}
+        result_monitor = self.vm.qmp('human-monitor-command', **args)
+        if self.device_name not in result_monitor['return']:
+            raise exceptions.TestFail('Could not find %s in monitor info usb output' % self.device_name)
+        self.check_io_errors()
 
-        if e_msg:
-            raise exceptions.TestFail('USB boot test found problems in: %s' % " ".join(e_msg))
+    def test_shows_guest_os(self):
+        """
+        Verify that the device shows up in the guest OS.
+        """
+        check_cmd = self.params.get('virt.tests.usb_boot.check_cmd', 'lsusb -v')
+        result_check = self.vm.remote.run(check_cmd)
+        device_found = False
+        for line in result_check.stdout.splitlines():
+            if self.device_name in line:
+                device_found = True
+        if not device_found:
+            raise exceptions.TestFail('Could not find %s in check command %s output' % (self.device_name, check_cmd))
+        self.check_io_errors()
 
-    def cleanup(self):
+    def tearDown(self):
         if self.vm:
-            if self.vm.remote:
-                self.vm.remote.run('shutdown -h now')
-                # TODO: Wait for machine to go down
             self.vm.power_off()


### PR DESCRIPTION
* Avocado tests now behave more like unittests, no
  more action() and cleanup() methods have to be
  defined

* Avocado params are no longer dictionaries

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>