### PR TITLE
qemu: Modify tests to use proper paths for params

### DIFF
--- a/qemu/run_iozone.py.data/run_iozone.yaml
+++ b/qemu/run_iozone.py.data/run_iozone.yaml
@@ -1,12 +1,16 @@
-iozone:
-    virt.guest.image_path: /home/user/avocado/data/images/distro-with-iozone.qcow2
-    virt.guest.user: john_doe
-    virt.guest.password: pass1
-    2472b6c:
-        virt.qemu.paths.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_2472b6c
-    f383611:
-        virt.qemu.paths.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_f383611
-    1b53eab:
-        virt.qemu.paths.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_1b53eab
-    f5bebbb:
-        virt.qemu.paths.qemu_bin: /home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_f5bebbb
+plugins:
+    virt:
+        guest:
+            image_path: "/home/user/avocado/data/images/distro-with-iozone.qcow2"
+            user: "john_doe"
+            password: "pass1"
+        qemu:
+            paths: !mux
+                2472b6c:
+                    qemu_bin: "/home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_2472b6c"
+                f383611:
+                    qemu_bin: "/home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_f383611"
+                1b53eab:
+                    qemu_bin: "/home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_1b53eab"
+                f5bebbb:
+                    qemu_bin: "/home/user/code/qemu/x86_64-softmmu/qemu-system-x86_64_f5bebbb"

--- a/qemu/usb_boot.py
+++ b/qemu/usb_boot.py
@@ -31,11 +31,12 @@ class USBBootTest(test.VirtTest):
         Add a USB device to a QEMU VM
         """
         super(USBBootTest, self).setUp()
-        self.device_name = self.params.get('virt.tests.usb_boot.device_name', default='QEMU USB Tablet')
-        usb_bus_cmdline = self.params.get('virt.tests.usb_boot.usb_bus_cmdline',
+        self.device_name = self.params.get('device_name',
+                                           default='QEMU USB Tablet')
+        usb_bus_cmdline = self.params.get('usb_bus_cmdline',
                                           default='-device piix3-usb-uhci,id=usbtest,bus=pci.0,addr=05')
         self.vm.devices.add_cmdline(usb_bus_cmdline)
-        usb_device_cmdline = self.params.get('virt.tests.usb_boot.usb_device_cmdline',
+        usb_device_cmdline = self.params.get('device_cmdline',
                                              default='-device usb-tablet,id=usb-tablet,bus=usbtest.0,port=1')
         self.vm.devices.add_cmdline(usb_device_cmdline)
         self.vm.power_on()
@@ -68,7 +69,7 @@ class USBBootTest(test.VirtTest):
         """
         Verify that the device shows up in the guest OS.
         """
-        check_cmd = self.params.get('virt.tests.usb_boot.check_cmd', default='lsusb -v')
+        check_cmd = self.params.get('check_cmd', default='lsusb -v')
         result_check = self.vm.remote.run(check_cmd)
         device_found = False
         for line in result_check.stdout.splitlines():

--- a/qemu/usb_boot.py.data/usb_boot.yaml
+++ b/qemu/usb_boot.py.data/usb_boot.yaml
@@ -1,15 +1,15 @@
-usb_boot:
-    virt.tests.usb_boot.usb_bus_cmdline: '-device piix3-usb-uhci,id=usbtest,bus=pci.0,addr=05'
-    virt.tests.usb_boot.check_cmd: lsusb -v
-    tablet:
-        virt.tests.usb_boot.usb_device_cmdline: '-device usb-tablet,id=usb-tablet,bus=usbtest.0,port=1'
-        virt.tests.usb_boot.device_name: 'QEMU USB Tablet'
-    keyboard:
-        virt.tests.usb_boot.usb_device_cmdline: '-device usb-kbd,id=usb-kbd,bus=usbtest.0,port=1'
-        virt.tests.usb_boot.device_name: 'QEMU USB Keyboard'
-    mouse:
-        virt.tests.usb_boot.usb_device_cmdline: '-device usb-mouse,id=usb-mouse,bus=usbtest.0,port=1'
-        virt.tests.usb_boot.device_name: 'QEMU USB Mouse'
-    audio:
-        virt.tests.usb_boot.usb_device_cmdline: '-device usb-audio,id=usb-audio,bus=usbtest.0,port=1'
-        virt.tests.usb_boot.device_name: 'QEMU USB Audio'
+!mux
+usb_bus_cmdline: '-device piix3-usb-uhci,id=usbtest,bus=pci.0,addr=05'
+check_cmd: "lsusb -v"
+tablet:
+    device_cmdline: '-device usb-tablet,id=usb-tablet,bus=usbtest.0,port=1'
+    device_name: 'QEMU USB Tablet'
+keyboard:
+    device_cmdline: '-device usb-kbd,id=usb-kbd,bus=usbtest.0,port=1'
+    device_name: 'QEMU USB Keyboard'
+mouse:
+    device_cmdline: '-device usb-mouse,id=usb-mouse,bus=usbtest.0,port=1'
+    device_name: 'QEMU USB Mouse'
+audio:
+    device_cmdline: '-device usb-audio,id=usb-audio,bus=usbtest.0,port=1'
+    device_name: 'QEMU USB Audio'


### PR DESCRIPTION
This patch modifies the existing yaml files to use the proper params
paths.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>