### PR TITLE
qemu.run_iozone: Add note about prerequisites

### DIFF
--- a/qemu/run_iozone.py
+++ b/qemu/run_iozone.py
@@ -20,6 +20,12 @@ from avocado.virt import test
 
 class RunIOZoneTest(test.VirtTest):
 
+    """
+    Runs IOzone inside the VM
+
+    :warning: It requires iozone to be pre-installed.
+    """
+
     def test_iozone(self):
         self.vm.power_on()
         self.vm.login_remote()


### PR DESCRIPTION
The run_iozone test requires iozone to be installed.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>