### PR TITLE
avocado virt tests: Add avocado loading tags

### DIFF
--- a/qemu/boot.py
+++ b/qemu/boot.py
@@ -21,6 +21,8 @@ class BootTest(test.VirtTest):
 
     """
     Simple test which boots VM, logins and powers it off.
+
+    :avocado: enable
     """
 
     def test_boot(self):

--- a/qemu/migration/migration.py
+++ b/qemu/migration/migration.py
@@ -24,6 +24,7 @@ class MigrationTest(test.VirtTest):
 
     :param migration_mode: Migration method
     :param migration_iterations: How many times to migrate the VM
+    :avocado: enable
     """
 
     def test_migrate(self):

--- a/qemu/run_iozone.py
+++ b/qemu/run_iozone.py
@@ -24,6 +24,7 @@ class RunIOZoneTest(test.VirtTest):
     Runs IOzone inside the VM
 
     :warning: It requires iozone to be pre-installed.
+    :avocado: enable
     """
 
     def test_iozone(self):

--- a/qemu/usb_boot.py
+++ b/qemu/usb_boot.py
@@ -28,6 +28,7 @@ class USBBootTest(test.VirtTest):
     :param usb_bus_cmdline: Cmdline option to add the usb bus
     :param device_cmdline: Cmdline option to add the device
     :param check_cmd: Cmd to be ran in guest to query for the device_name
+    :avocado: enable
     """
     device_name = None
 


### PR DESCRIPTION
Avocado now has a safe loading mechanism that
is more thoroughly described in the WritingTests
section (Test Tags). The example virt tests
contained here now do need the :avocado: enable
tags to work, so let's add them.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>