### PR TITLE
Set --enable-kvm for our example tests

### DIFF
--- a/qemu/boot.py
+++ b/qemu/boot.py
@@ -26,6 +26,7 @@ class BootTest(test.VirtTest):
     """
 
     def test_boot(self):
+        self.tevm.devices.add_cmdline('--enable-kvm')
         self.vm.power_on()
         self.vm.login_remote()
 

--- a/qemu/migration/migration.py
+++ b/qemu/migration/migration.py
@@ -28,6 +28,7 @@ class MigrationTest(test.VirtTest):
     """
 
     def test_migrate(self):
+        self.vm.devices.add_cmdline('--enable-kvm')
         self.vm.power_on()
         migration_mode = self.params.get('migration_mode', default='tcp')
         for _ in xrange(self.params.get('migration_iterations', default=4)):

--- a/qemu/run_iozone.py
+++ b/qemu/run_iozone.py
@@ -28,6 +28,7 @@ class RunIOZoneTest(test.VirtTest):
     """
 
     def test_iozone(self):
+        self.vm.devices.add_cmdline('--enable-kvm')
         self.vm.power_on()
         self.vm.login_remote()
         self.whiteboard = self.vm.remote.run('iozone -a').stdout

--- a/qemu/usb_boot.py
+++ b/qemu/usb_boot.py
@@ -45,6 +45,7 @@ class USBBootTest(test.VirtTest):
         usb_device_cmdline = self.params.get('device_cmdline',
                                              default='-device usb-tablet,id=usb-tablet,bus=usbtest.0,port=1')
         self.vm.devices.add_cmdline(usb_device_cmdline)
+        self.vm.devices.add_cmdline('--enable-kvm')
         self.vm.power_on()
         self.vm.login_remote()
         self.vm.remote.run('dmesg -c')


### PR DESCRIPTION
Qemu can be compilled without kvm enabled. Let's make sure
our example tests will run fast.

Signed-off-by: Amador Pahim <apahim@redhat.com>